### PR TITLE
Fixed code execution bug on count-git-tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,17 @@ import isGit from 'is-git-repository';
 import { platform } from 'os';
 import makepath from 'path';
 import pathIsAbsolute from 'path-is-absolute';
+import shellescape from 'shell-escape';
 
 const cwd = process.cwd();
+
+// escape bad arguments
+var escapeShell = function(cmd) {
+  if(cmd !== undefined){
+    var arg = cmd.toString().split(" ");
+    return shellescape(arg);
+  }
+}
 
 const countGitTags = ({ path, local } = {}) => {
   let countOfTags = 0;
@@ -12,6 +21,9 @@ const countGitTags = ({ path, local } = {}) => {
   let thisPath = path || cwd;
   thisPath = pathIsAbsolute(thisPath) ? thisPath : makepath.join(cwd, thisPath);
   const thisLocal = local === undefined ? true : local;
+  
+  thisPath = escapeShell(thisPath);
+  thisLocal = escapeShell(thisLocal);
 
   if (!isGit(thisPath)) {
     return 0;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "execa": "^0.6.1",
     "fs-extra": "^3.0.1",
     "is-git-repository": "^1.1.1",
-    "path-is-absolute": "^1.0.1"
+    "path-is-absolute": "^1.0.1",
+    "shell-escape": "^0.2.0"
   },
   "devDependencies": {
     "ava": "^0.18.2",


### PR DESCRIPTION
### 📊 Metadata *

Remote Code Execution Vulnerability
#### Bounty URL: https://www.huntr.dev/app/bounties/open/1-npm-node-count-git-tags

### ⚙️ Description *

Fixed the code execution by escaping the shell argument using the [shell-escape](https://www.npmjs.com/package/shell-escape) library.

### 💻 Technical Description *

shell-escape is used to escape and stringify an array of arguments to be executed on the shell. There were multiple instances on the `index.js` in which the user-supplied input is concatenated into command strings, unsanitized, which is then passed to `execa.shellSync()` which triggers the code execution. This is mitigated using the shell-escape library.

### 🐛 Proof of Concept (PoC) *

Create a project with a vulnerable package and run the following snippet and listen to requests on localhost:80.

```javascript
const countGitTags = require('count-git-tags');
countGitTags({ path: '.git;curl "http://localhost/RCE"' });
```

![before](https://user-images.githubusercontent.com/16708391/88452907-321b3100-ce80-11ea-9c33-a34564e540b1.PNG)

### 🔥 Proof of Fix (PoF) *

After applying the fix, the `escape-shell` module properly sanitizes the user-supplied information before passing into the `execa.shellSync()`. and the curl command is no more executed. Hence code execution is mitigated.

![after](https://user-images.githubusercontent.com/16708391/88452926-5b3bc180-ce80-11ea-82b0-372c4591821e.PNG)


